### PR TITLE
Leak example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,69 @@ bin
 .factorypath
 .settings
 logs
+### Scala template
+*.class
+*.log
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+### SBT template
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
+
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.lib/

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ project/boot/
 project/plugins/project/
 .history
 .lib/
+/.idea/

--- a/exception-examples-api/src/main/scala/com/example/hello/api/ExceptionExamplesService.scala
+++ b/exception-examples-api/src/main/scala/com/example/hello/api/ExceptionExamplesService.scala
@@ -19,14 +19,14 @@ trait ExceptionExamplesService extends Service {
 
   def hello(id: String): ServiceCall[NotUsed, String]
 
-  def leaky(id: String): ServiceCall[NotUsed, String]
+  def leaky: ServiceCall[NotUsed, String]
 
   override final def descriptor = {
     import Service._
     named("exception-examples")
       .withCalls(
         pathCall("/api/hello/:id", hello _),
-        pathCall("/api/leaky/:id", leaky _)
+        pathCall("/api/leaky", leaky _)
       )
       //.withExceptionSerializer(new CustomExceptionSerializer())
       .withAutoAcl(true)

--- a/exception-examples-api/src/main/scala/com/example/hello/api/ExceptionExamplesService.scala
+++ b/exception-examples-api/src/main/scala/com/example/hello/api/ExceptionExamplesService.scala
@@ -1,14 +1,15 @@
 package com.example.hello.api
 
 import akka.util.ByteString
-import akka.{ Done, NotUsed }
+import akka.{Done, NotUsed}
+import com.lightbend.lagom.scaladsl.api.Service.pathCall
 import com.lightbend.lagom.scaladsl.api.broker.Topic
-import com.lightbend.lagom.scaladsl.api.broker.kafka.{ KafkaProperties, PartitionKeyStrategy }
-import com.lightbend.lagom.scaladsl.api.deser.{ DefaultExceptionSerializer, ExceptionSerializer, RawExceptionMessage }
-import com.lightbend.lagom.scaladsl.api.transport.{ MessageProtocol, TransportException }
-import com.lightbend.lagom.scaladsl.api.{ Service, ServiceCall }
-import play.api.{ Environment, Mode }
-import play.api.libs.json.{ Format, Json }
+import com.lightbend.lagom.scaladsl.api.broker.kafka.{KafkaProperties, PartitionKeyStrategy}
+import com.lightbend.lagom.scaladsl.api.deser.{DefaultExceptionSerializer, ExceptionSerializer, RawExceptionMessage}
+import com.lightbend.lagom.scaladsl.api.transport.{MessageProtocol, TransportException}
+import com.lightbend.lagom.scaladsl.api.{Service, ServiceCall}
+import play.api.{Environment, Mode}
+import play.api.libs.json.{Format, Json}
 
 import scala.collection.immutable.Seq
 import scala.util.control.NoStackTrace
@@ -18,13 +19,16 @@ trait ExceptionExamplesService extends Service {
 
   def hello(id: String): ServiceCall[NotUsed, String]
 
+  def leaky(id: String): ServiceCall[NotUsed, String]
+
   override final def descriptor = {
     import Service._
     named("exception-examples")
       .withCalls(
-        pathCall("/api/hello/:id", hello _)
+        pathCall("/api/hello/:id", hello _),
+        pathCall("/api/leaky/:id", leaky _)
       )
-      .withExceptionSerializer(new CustomExceptionSerializer())
+      //.withExceptionSerializer(new CustomExceptionSerializer())
       .withAutoAcl(true)
   }
 }

--- a/exception-examples-impl/src/main/resources/application.conf
+++ b/exception-examples-impl/src/main/resources/application.conf
@@ -2,3 +2,4 @@
 #
 play.application.loader = com.example.hello.impl.ExceptionExamplesLoader
 
+play.http.secret.key="fk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@52"

--- a/exception-examples-impl/src/main/scala/com/example/hello/impl/ExceptionExamplesServiceImpl.scala
+++ b/exception-examples-impl/src/main/scala/com/example/hello/impl/ExceptionExamplesServiceImpl.scala
@@ -14,11 +14,14 @@ class ExceptionExamplesServiceImpl() extends ExceptionExamplesService {
   }
 
   /**
-    * TO TEST: in a console, do `sbt docker:publishLocal`, and then lanch the generated script:
-    * -------   `./exception-examples-impl/target/docker/stage/opt/docker/bin/exception-examples-impl`
+    * TO TEST:
+    * --------
     *
+    * - in a console, do:             `sbt clean docker:publishLocal`
+    * - launch the generated script:  `./exception-examples-impl/target/docker/stage/opt/docker/bin/exception-examples-impl`
+    * - in another console:           `curl http://localhost:9000/api/leaky`
     */
-  override def leaky(id: String): ServiceCall[NotUsed, String] = ServiceCall { _ =>
+  override def leaky: ServiceCall[NotUsed, String] = ServiceCall { _ =>
     val cause = new RuntimeException(s"This message should not leak to the public")
 
     Future.failed(BadRequest(cause))

--- a/exception-examples-impl/src/main/scala/com/example/hello/impl/ExceptionExamplesServiceImpl.scala
+++ b/exception-examples-impl/src/main/scala/com/example/hello/impl/ExceptionExamplesServiceImpl.scala
@@ -1,8 +1,11 @@
 package com.example.hello.impl
 
-import com.example.hello.api.{ CustomException, ExceptionExamplesService }
+import akka.NotUsed
+import com.example.hello.api.{CustomException, ExceptionExamplesService}
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.api.transport.BadRequest
+
+import scala.concurrent.Future
 
 class ExceptionExamplesServiceImpl() extends ExceptionExamplesService {
 
@@ -10,5 +13,14 @@ class ExceptionExamplesServiceImpl() extends ExceptionExamplesService {
     throw BadRequest(new CustomException(s"Hello $id "))
   }
 
+  /**
+    * TO TEST: in a console, do `sbt docker:publishLocal`, and then lanch the generated script:
+    * -------   `./exception-examples-impl/target/docker/stage/opt/docker/bin/exception-examples-impl`
+    *
+    */
+  override def leaky(id: String): ServiceCall[NotUsed, String] = ServiceCall { _ =>
+    val cause = new RuntimeException(s"This message should not leak to the public")
 
+    Future.failed(BadRequest(cause))
+  }
 }


### PR DESCRIPTION
I implemented an example of a leak I want to avoid in order to help me work on the solution.

Here is the response the `leaky` endpoint produces:
```
{"name":"BadRequest","detail":"This message should not leak to the public"}
```